### PR TITLE
Remove Duplicate Menu Item

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -10,7 +10,7 @@
     })(window,document,'script','dataLayer','GTM-WWM6CD5');</script>
     <!-- End Google Tag Manager -->
     <meta charset="utf-8">
-    <title>Reesykle - Eco-Decentralized Ecosystem</title>
+    <title>Reesykle - Eco-Decentralized ecosystem</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="description" content="Reesykle is an eco-decentralized ecosystem that thrives on community.">
     <link href="assets/css/loaders/loader-typing.css" rel="stylesheet" type="text/css" media="all" />
@@ -55,7 +55,7 @@
                   <a href="#features" data-smooth-scroll class="nav-link dropdown-toggle">Feature</a>
                 </li>
                 <li class="nav-item dropdown">
-                  <a href="#ecosystem" data-smooth-scroll class="nav-link dropdown-toggle">Ecosystem</a>
+                  <a href="#ecosystem" data-smooth-scroll class="nav-link dropdown-toggle">ecosystem</a>
                 </li>
                 <li class="nav-item dropdown">
                   <a href="#rewards" data-smooth-scroll class="nav-link dropdown-toggle">Rewards</a>
@@ -65,9 +65,6 @@
                 </li>
                 <li class="nav-item dropdown">
                   <a href="#how-to-buy" data-smooth-scroll class="nav-link dropdown-toggle">Buy</a>
-                </li>
-                <li class="nav-item dropdown">
-                  <a href="#ecosystem" data-smooth-scroll class="nav-link dropdown-toggle">ecosystem</a>
                 </li>
               </ul>
             </div>
@@ -203,15 +200,15 @@
         <img src="assets/img/dividers/divider-3.svg" alt="graphical divider" data-inject-svg />
       </div>
     </section>
-    <!--Ecosystem-->
+    <!--ecosystem-->
     <section id="ecosystem">
       <div class="container">
         <div class="row justify-content-center text-center mb-6">
           <div class="col-xl-8 col-lg-9">
-            <h2 class="display-4 mx-xl-6">Ecosystem</h2>
+            <h2 class="display-4 mx-xl-6">ecosystem</h2>
             <p class="lead">
-              The Reesykle Ecosystem is young, and rapidly growing. Here's a quick overview of a few components
-              that make up the Reesykle Ecosystem.
+              The Reesykle ecosystem is young, and rapidly growing. Here's a quick overview of a few components
+              that make up the Reesykle ecosystem.
             </p>
           </div>
         </div>
@@ -336,7 +333,7 @@
                   One of the most ambitious milestones in Reesykle's journey to maturity is to design and build
                   eco-sustainable properties and communities for rental purposes, thus creating the very first
                   Decentralized Eco Real Estate Market (DERM). These properties will not be owned by a single entity,
-                  they will be owned by all members (holders) that make up the Reesykle Ecosystem. The income generated
+                  they will be owned by all members (holders) that make up the Reesykle ecosystem. The income generated
                   from these properties will be distributed to members (holders) in the form of dividends on a daily,
                   weekly, monthly and yearly basis. How much you earn in dividends is contingent on the amount of Sykle
                   tokens that you own.
@@ -587,7 +584,7 @@
           <div class="col-md-6" data-aos="fade">
             <h3 class="h1">Sapling Stage</h3>
             <p class="lead">
-              The sapling stage is all about establishing the technological foundation that will allow us to grow into the mature stage. In this stage, Reesykle is introducing Terra, Reesykle's very own blockchain.  Terra will be used to run the first Decentralized Eco Real Estate Market (DERM), a decentralized, eco-sustainable real estate market that is not owned by a single entity, but rather a decentralized/distributed group of individuals that make up the Reesykle Ecosystem, AKA, you, the holder. No banks or middle-men involved.
+              The sapling stage is all about establishing the technological foundation that will allow us to grow into the mature stage. In this stage, Reesykle is introducing Terra, Reesykle's very own blockchain.  Terra will be used to run the first Decentralized Eco Real Estate Market (DERM), a decentralized, eco-sustainable real estate market that is not owned by a single entity, but rather a decentralized/distributed group of individuals that make up the Reesykle ecosystem, AKA, you, the holder. No banks or middle-men involved.
             </p>
             <ul class="list-unstyled mb-0">
               <li class="d-flex py-2">


### PR DESCRIPTION
# Overview
This PR remove the duplicate `ecosystem` menu item from the top navigation bar.